### PR TITLE
authentication_timeout is not a valid value for parameters

### DIFF
--- a/rds-mysql.config.yaml
+++ b/rds-mysql.config.yaml
@@ -14,8 +14,8 @@ family: mysql5.7
 
 deletion_policy: Snapshot
 
-parameters:
-  authentication_timeout: '60'
+# parameters:
+#   authentication_timeout: '60'
 
 # master_username: postgres
 # master_password: postgres


### PR DESCRIPTION
I think it is better not to define the param because no way to overwrite it and only adding.