### PR TITLE
Pull master username and password from SSM

### DIFF
--- a/rds-mysql.cfndsl.rb
+++ b/rds-mysql.cfndsl.rb
@@ -38,8 +38,8 @@ CloudFormation do
     Engine 'mysql'
     EngineVersion engine_version
     DBParameterGroupName Ref('ParametersRDS')
-    MasterUsername  master_username if defined? master_username
-    MasterUserPassword master_password if defined? master_password
+    MasterUsername  FnJoin('', [ '{{resolve:ssm:', FnSub(master_login['username_ssm_param']), ':1}}' ]) if defined? master_login
+    MasterUserPassword FnJoin('', [ '{{resolve:ssm-secure:', FnSub(master_login['password_ssm_param']), ':1}}' ]) if defined? master_login
     DBSnapshotIdentifier  Ref('RDSSnapshotID')
     DBSubnetGroupName  Ref('SubnetGroupRDS')
     VPCSecurityGroups [Ref('SecurityGroupRDS')]

--- a/rds-mysql.config.yaml
+++ b/rds-mysql.config.yaml
@@ -17,8 +17,9 @@ deletion_policy: Snapshot
 # parameters:
 #   authentication_timeout: '60'
 
-# master_username: postgres
-# master_password: postgres
+# master_login:
+#   username_ssm_param: /rds/RDS_MASTER_USERNAME
+#   password_ssm_param: /rds/RDS_MASTER_PASSWORD
 
 security_group:
   -


### PR DESCRIPTION
Use SSM to store master username and master password for RDS instance.
Credentials are pulled from SSM on deployment.
Removes credentials from templates.